### PR TITLE
Update `imageio` to version `2.19.3`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.9.0" %}
-{% set sha256 = "52ddbaeca2dccf53ba2d6dec5676ca7bc3b2403ef8b37f7da78b7654bb3e10f0" %}
+{% set version = "2.10.3" %}
+{% set sha256 = "469c59fe71c81cdc41c84f842d62dd2739a08fac8cb85f5a518a92a6227e2ed6" %}
 
 package:
   name: imageio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
   entry_points:
     - imageio_download_bin = imageio.__main__:download_bin_main
@@ -24,7 +24,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3
+    - python >=3.7
     - numpy
     - pillow >=8.3.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - python >=3
     - numpy
-    - pillow
+    - pillow >=8.3.2
 
 test:
   imports:
@@ -32,6 +32,7 @@ test:
   commands:
     - imageio_download_bin -h
     - imageio_remove_bin -h
+    - pip check
 
 about:
   home: https://imageio.github.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.10.3" %}
-{% set sha256 = "469c59fe71c81cdc41c84f842d62dd2739a08fac8cb85f5a518a92a6227e2ed6" %}
+{% set version = "2.19.3" %}
+{% set sha256 = "0c9df80e42f2ee68bea92001e7fcf612aa149910efe040eb757f5ce323250ae1" %}
 
 package:
   name: imageio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3.7
+    - python 
     - numpy
     - pillow >=8.3.2
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,9 @@ build:
 requirements:
   host:
     - pip
-    - python >=3
+    - python
+    - wheel
+    - setuptools
   run:
     - python >=3
     - numpy
@@ -29,10 +31,13 @@ requirements:
 test:
   imports:
     - imageio
+    - imageio.config
   commands:
     - imageio_download_bin -h
     - imageio_remove_bin -h
     - pip check
+  requires:
+    - pip
 
 about:
   home: https://imageio.github.io
@@ -41,6 +46,7 @@ about:
   summary: A Python library for reading and writing image data
   license: BSD-2-Clause
   license_file: LICENSE
+  license_family: BSD
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
`imageio` version `2.19.3`
1. - [x] Check the upstream
    https://github.com/imageio/imageio/tree/v2.19.3
2. - [x] Check the pinnings

  `setuptools`
  https://github.com/imageio/imageio/blob/master/setup.py#L31

  `wheel`
  https://github.com/imageio/imageio/blob/master/setup.py#L37

  `numpy` `pillow >= 8.3.2`
  https://github.com/imageio/imageio/blob/master/setup.py#L177

  `python >=3.7`
  https://github.com/imageio/imageio/blob/master/setup.py#L240

3. - [x] Check the changelogs
    https://github.com/imageio/imageio/tree/v2.19.3/CHANGELOG.md
    
    `2.9.0`
Fixed
More robust loading of FEI SEM data (#529 by jon-lab).
https://github.com/imageio/imageio/pull/529

Fix webcam not working on Win10 (#525).
https://github.com/imageio/imageio/pull/525

Added
Add a few standard images useful to 3D visualization.
The timeout used in HTTP requests can now be set with an environment variable (#534 by Johann Neuhauser).
https://github.com/imageio/imageio/pull/534

The DICOM plugin can now used gdcm for compressed transfer formats.
Better support for itk/sitk plugins (#530 by Jonathan Daniel).
https://github.com/imageio/imageio/pull/530

Test coverage and CI for ARM (#518 by odidev).
https://github.com/imageio/imageio/pull/518

`2.10.0`

Feature
Allow pillow to write/encode to byte strings (#669) (b5df806)
https://github.com/imageio/imageio/pull/669

Add CD pipeline (#667) (6dce3ab)
https://github.com/imageio/imageio/pull/667

Fail PIL write if extension isnt supported (0dc33d3)
https://github.com/imageio/imageio/commit/0dc33d3e13f4c2c3f9b9f7e1622a26d0e8338ef7

Make imopen use core.Request (c51fdb0)
https://github.com/imageio/imageio/commit/c51fdb06b21596a35e9d36f3090ccef9b710fa07

Fix
Bump pillow to 8.3.2 (#661) (a5ce49f)
https://github.com/imageio/imageio/pull/661

Undo previous commit (f4c2e74)
https://github.com/imageio/imageio/commit/f4c2e74f45c261c41e50ef97ca201b8239386ff7

Bump required pillow version (1a4456c)
https://github.com/imageio/imageio/commit/1a4456ced83b71f6c4e47701cbf3669d2dcd6dff

Avoid pillow 8.3.0 (#656) (abe3cc2)
https://github.com/imageio/imageio/pull/656

Close request if no backend was found (1f8ff6b)
https://github.com/imageio/imageio/commit/1f8ff6b4728385f776b4707471c039dde8efb60d

Introduce InitializationError (974fdc5)
https://github.com/imageio/imageio/commit/974fdc5cf977d73039b22a60e73195ddc5dc46bb

Linting (e25f06f)
https://github.com/imageio/imageio/commit/e25f06fa942b7452f34b4c6c983dfccbc12b4384

Merge master into feature (6576783)
https://github.com/imageio/imageio/commit/6576783456270d024057f280197eec51c9bbf476

Instantiate plugins once (081f3e6)
https://github.com/imageio/imageio/commit/081f3e6b3740c81484fec92f5e1b13424a406e34

Make FITS the preferred plugin for FITS files (#637) (6fbab81)
https://github.com/imageio/imageio/pull/637

Remove compromised token (#635) (7fdc558)
 https://github.com/imageio/imageio/pull/635

Get images from imageio not firefoxmetzger (9da8339)
https://github.com/imageio/imageio/commit/9da8339fd18dd69c00f9f2eda5dc1b29f421a7cf

Throw-away requests for get_reader/get_writer (cf83968)
https://github.com/imageio/imageio/commit/cf839683205f409b28e7a17be3580a80be66abb3

Black + flake8 (53ed8d8)
https://github.com/imageio/imageio/commit/53ed8d823dd4b036e5aebcd2f0529aad67ef3831

Test mvolread with mvol image (3a03d26)
https://github.com/imageio/imageio/commit/3a03d267e832a57017c376a3c1649c0dd42d3927

Investigate pypy failure (9d63acc)
https://github.com/imageio/imageio/commit/9d63accc8a587bff2a228c1f69dc89b5004934a4

Remove dublicate checks (7148fa9)
https://github.com/imageio/imageio/commit/7148fa9fec72b06ac328db7246278e59e40c3d9b

Remove dublicate code (9a99417)
https://github.com/imageio/imageio/commit/9a99417abaadf0e536ff763d8046baa78fe5c85b

Flake8 + black (42a02ed)
https://github.com/imageio/imageio/commit/42a02edc6cd2aad51cb67b4782a643fa5fbad870

Raise error for invalud modes in py3.6 (c91ae9c)
https://github.com/imageio/imageio/commit/c91ae9c400b12932bf213058ab48f9936fff225c

Black + flake8 (abe7199)
https://github.com/imageio/imageio/commit/42a02edc6cd2aad51cb67b4782a643fa5fbad870

Pillow changed gif reading. updating test (2ebe936)
https://github.com/imageio/imageio/commit/2ebe936872329abc3be7e58b375f3d6e8481cd5c

Flake8 (6debb11)
https://github.com/imageio/imageio/commit/6debb110685a26899197b8b224cc9d4ff92cee6e

Blackify (6676a62)
https://github.com/imageio/imageio/commit/6676a628f9cacdcfcffb1fd6b7580c52fc023326

New black formatting rules (#630) (659f4f7)
https://github.com/imageio/imageio/pull/630

Merge master into branch (edad86f)
https://github.com/imageio/imageio/commit/edad86f9b8f20a88a8efa9aa79d2fd170ebfa6d2

Make Request.Mode an enum (#622) (dc2d06b)
https://github.com/imageio/imageio/pull/622

Fix highlighting of installation command (#615) (9df61d2)
https://github.com/imageio/imageio/pull/615

Remove double import (388e57d)
https://github.com/imageio/imageio/commit/388e57d3edb582f6b2e4aadeb97e13b0809d582a

Merge master into v3.0.0 (7443ffd)
https://github.com/imageio/imageio/commit/7443ffd5fa6d9c0a0566f1830e51ef21ec58ffcb

Documentation
Refactor plugin docs (#666) (787db4b)
https://github.com/imageio/imageio/pull/666

Fix typo (#659) (bb13525)
https://github.com/imageio/imageio/pull/659

Fixed Typo (#653) (eb24eaa)
https://github.com/imageio/imageio/pull/653

Update DOI (#650) (b4f186f)
https://github.com/imageio/imageio/pull/650

Added missing docstring to function (6625430)
https://github.com/imageio/imageio/commit/66254303eea9c4a8ef9075e2e31dc0163955db8e

Clarify missing method (2fd5116)
https://github.com/imageio/imageio/commit/2fd5116cd5d8ac9b2495ef853a22a46d861744bc

Update Website Link (#634) (2f058d7)
https://github.com/imageio/imageio/pull/634

Polish imopen docstrings (7052cd8)
https://github.com/imageio/imageio/commit/7052cd83b402efa0fd43540c3400a9aad75a6d76

Clarify documentation on .tif handling (#625) (68bb515)
https://github.com/imageio/imageio/pull/625

Add repo location to developer instructions (#584) (2ce79b9)
https://github.com/imageio/imageio/pull/584

`2.10.1`
Fix
Install ImageIO dependencies during release wheel build (#671) (f1ee22a)
https://github.com/imageio/imageio/pull/671

`2.10.2`
Fix
Allow devices above in ffmpeg (#675) (1fc4208)
https://github.com/imageio/imageio/pull/675

Documentation
Align README.md with new docs (#672) (51a8cd5)
https://github.com/imageio/imageio/pull/672

`2.10.3`
Fix
Fix file extension bug when filename contains '#'. (#678) (f3fa631)
https://github.com/imageio/imageio/pull/678

`2.10.4`
Fix
Consistently handle file opening/closing (#673) (b852f45)
https://github.com/imageio/imageio/pull/673

Documentation
Reorder getting started menu (#683) (94f479e)
https://github.com/imageio/imageio/pull/683

`2.10.5`
Fix
Resolve regression on imageJ TIFF hyperstacks (#682) (7dc9b25)
https://github.com/imageio/imageio/pull/682

`2.11.0`
Feature
Choose plugin based on extension and plugin lazy-import (#680) (bdbe699)
https://github.com/imageio/imageio/pull/680

`2.11.1`
Fix
Fix BytesIO regression for legacy pillow (#688) (924e1c5)
https://github.com/imageio/imageio/pull/688

`2.12.0`
Feature
Allow plugin objects in plugin kwarg (#689) (8f0f689)
https://github.com/imageio/imageio/pull/689

`2.13.0`
Documentation
Fix typos. (#696) (67239f3)
https://github.com/imageio/imageio/pull/696

`2.13.1`
Fix
Only run CD on main and fail fast (#698) (e90494a)
https://github.com/imageio/imageio/pull/698

Lazy-import plugin namespace (#693) (73695ae)
https://github.com/imageio/imageio/pull/693

`2.13.2`
Fix
Only force webcam FPS on Mac (#701) (28b1d0d)
https://github.com/imageio/imageio/pull/701

`2.13.3`
Fix
Allow TIFF to write bytes and file objects (#704) (9c765c3)
https://github.com/imageio/imageio/pull/704

`2.13.4`
Fix
Update tested pypy versions (#713) (8a79104)
https://github.com/imageio/imageio/pull/713

Documentation
Update download tracker (#712) (a265c51)
https://github.com/imageio/imageio/pull/712

`2.13.5`
Fix
Clean up PillowPlugin destructor (#714) (104171b)
https://github.com/imageio/imageio/pull/714

Close standard streams after webcam access (#711) (9c434e0)
https://github.com/imageio/imageio/pull/711

`2.14.0`
Fix
Handle pillow9 GIFs (#724) (836b7a9)
https://github.com/imageio/imageio/pull/724

Feature
Allow mode=None when writing with pillow (#722) (7be2712)
https://github.com/imageio/imageio/pull/722

Other
Add repo to PYTHONPATH in should_release? (#728) (a22d810)
https://github.com/imageio/imageio/pull/728

Reorganize commit tags (#717) (c57bf85)
https://github.com/imageio/imageio/pull/717

Reduce release frequency to weekly (#716) (51f552b)
https://github.com/imageio/imageio/pull/716

`2.14.1`

Fix
Avoid raw bytes in exception message (#733) (6252636)
https://github.com/imageio/imageio/pull/733

`2.15.0`
Fix
Fix webcam FPS settings on MacOS (#738) (a08b0c4)
https://github.com/imageio/imageio/pull/738

Feature
Add format_hint to v3 API (#734) (dd538ec)
https://github.com/imageio/imageio/pull/734

Make tifffile read resolution metadata (#732) (4f7f334)
https://github.com/imageio/imageio/pull/732

Other
Make RTD fail on warnings during CI (#747) (252839c)
https://github.com/imageio/imageio/pull/747

Add missing ! to download tracker banner (#746) (8e8c546)
https://github.com/imageio/imageio/pull/746

Remove link to download tracker (#744) (33fe89f)
https://github.com/imageio/imageio/pull/744

Type annotations for pillow (#743) (269d9e1)
https://github.com/imageio/imageio/pull/743

Contribution guidelines (#729) (ff2e3fd)
https://github.com/imageio/imageio/pull/729

Deprecate python 3.6 support (#740) (e104505)
https://github.com/imageio/imageio/pull/740

`2.16.0`
Dedicated namespaces for APIs (#720)
https://github.com/imageio/imageio/pull/720

Improps and immeta (#739)
https://github.com/imageio/imageio/pull/739

Read metadata of current frame when iterating + APNG fast path (#750)
https://github.com/imageio/imageio/pull/750

`2.16.1`
bug fixes, (solve issue with zero in the denominator)
https://github.com/imageio/imageio/pull/753

update python requires to python 3.7
https://github.com/imageio/imageio/pull/757

Add section on freezing 
https://github.com/imageio/imageio/pull/759

`2.16.2`
license update
pillow format
solve spacing format
PIL palett handles fix

`2.17.0`
update documentations
add fast path pyav formats
add mypy support
New plugin for pyAV
add pluging defaults

`2.18.0`
update imopen types to make them more user friendly 
bug fixes with tifffile
bug fixes pyav doensn't flush the frame.

`2.19.0`
The OpenCV plugin is added to give support to certain file formats.
https://github.com/imageio/imageio/pull/791

`2.19.1`
fixed issues with broken links in the documentation.
Rename 
rename format_hint to extension and prefer it over actual file extensions
reset request when iterating over plugins

`2.19.2`
Add stacklevel=2 to some warnings
This is to improve the warning message quality
Don't treat im_mode ? as im_mode V


`2.19.3`
Add GA token 
Include py.typed in package 
Correctly read STK volumes in v3


4. - [x] Additional research
    https://github.com/conda-forge/imageio-feedstock/issues

    There are currently no open issues mentioned in the upstream

5. - [x] Verify the `dev_url`
    https://github.com/imageio/imageio
6. - [x] Verify the `doc_url`
    https://imageio.readthedocs.io/en/stable/
7. - [x] License is `spdx` compliant
    BSD-2-Clause
8. - [x] License family is present
    BSD
9. - [] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`
    setuptools
11. - [x] Verify if the package needs `wheel`
    wheel
12. - [x] `pip` in the test section
    pip
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
      The package has been modified to make architecture specific. 

15. - [x] Private variables are not mentioned on the recipe For example: (_private_variable)
 
Results:
- 

Based on the results and research we can conclude that it is safe to update `imageio` to version `2.19.3`
Currently there are no evidence of regressions or significant breaking changes that should prevent the update. 