### PR TITLE
Update `imageio` to version `2.16.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.9.0" %}
-{% set sha256 = "52ddbaeca2dccf53ba2d6dec5676ca7bc3b2403ef8b37f7da78b7654bb3e10f0" %}
+{% set version = "2.16.1" %}
+{% set sha256 = "7f123cb23a77ac5abe8ed4e7ad6a60831a82de2c5d123463dcf1d4278c4779d2" %}
 
 package:
   name: imageio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - wheel
     - python
   run:
-    # - python >=3
     - python
     - numpy >=1.20.0
     - pillow >=8.3.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
+  skip: true  # [py<37]
   entry_points:
     - imageio_download_bin = imageio.__main__:download_bin_main
     - imageio_remove_bin = imageio.__main__:remove_bin_main
@@ -20,26 +20,33 @@ build:
 requirements:
   host:
     - pip
-    - python >=3
+    - setuptools
+    - wheel
+    - python
   run:
-    - python >=3
-    - numpy
-    - pillow
+    # - python >=3
+    - python
+    - numpy >=1.20.0
+    - pillow >=8.3.2
 
 test:
+  requires:
+    - pip
   imports:
     - imageio
   commands:
+    - pip check
     - imageio_download_bin -h
     - imageio_remove_bin -h
 
 about:
   home: https://imageio.github.io
-  doc_url: https://imageio.readthedocs.io
+  doc_url: https://imageio.readthedocs.io/en/stable/
   dev_url: https://github.com/imageio/imageio
   summary: A Python library for reading and writing image data
   license: BSD-2-Clause
   license_file: LICENSE
+  license_family: BSD
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
`imageio` version `2.16.1`
1. - [x] Check the upstream

  https://github.com/imageio/imageio/tree/v2.16.1

2. - [x] Check the pinnings

minimum `python` version required is `3.7`
https://github.com/imageio/imageio/blob/v2.16.1/setup.py#L221

the package requires `numpy >= 1.20.0` and `pillow >= 8.3.2`
https://github.com/imageio/imageio/blob/v2.16.1/setup.py#L174

3. - [x] Check the changelogs

  https://github.com/imageio/imageio/blob/v2.16.1/CHANGELOG.md

  Most of the changes mentioned were bugfixes or new features added.

4. - [x] Additional research
    https://github.com/conda-forge/imageio-feedstock/issues

    There are currently no open issues mentioned in the upstream

5. - [x] Verify the `dev_url`
    https://github.com/imageio/imageio


6. - [x] Verify the `doc_url`

  https://imageio.readthedocs.io/en/stable/

  since a readirect occurs, the `doc_url:` has been updated to meet the final destination of the documentation.

7. - [x] License is `spdx` compliant
8. - [x] License family is present
9. - [x] Verify that the build number is correct
10. - [x] Verify if the package needs `setuptools`

  https://github.com/imageio/imageio/blob/v2.16.1/setup.py#L31

11. - [x] Verify if the package needs `wheel`

  https://github.com/imageio/imageio/blob/v2.16.1/setup.py#L37

12. - [x] `pip` in the test section
13. - [x] Veriy the test section
14. - [x] Verify if the package is `Architecture specific` or `Noarch`
15. - [x] Private variables are not mentioned on the recipe For example: ( _private )
 
Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is safe to update `imageio` to version `2.16.1`
