### PR TITLE
imageio 2.37.4 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,8 @@
 {% set name = "imageio" %}
 {% set version = "2.37.4" %}
-{% set deselect_tests = "" %}
-{% set deselect_tests = 'deselect_tests + " --deselect=tests/test_format.py::test_preferring_arbitrary"' %}
-{% set deselect_tests = 'deselect_tests + " --deselect=tests/test_format.py::test_missing_format"' %}
 
-# imageio-ffmpeg package is not available in channel
-# E       KeyError: 'imageio.plugins.ffmpeg'
-# E       AssertionError: assert 'NPZ' == 'FFMPEG'
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -28,7 +22,6 @@ requirements:
     - pip
     - python
     - setuptools >=61.0
-    - numpy {{ numpy }}
     - wheel
   run:
     - python
@@ -36,6 +29,13 @@ requirements:
     - pillow >=8.3.2
   run_constrained:
     - numpy >2
+
+# imageio-ffmpeg package is not available in channel
+# E       KeyError: 'imageio.plugins.ffmpeg'
+# E       AssertionError: assert 'NPZ' == 'FFMPEG'
+{% set deselect_tests = "" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_format.py::test_preferring_arbitrary" %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_format.py::test_missing_format" %}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,19 @@
 {% set name = "imageio" %}
-{% set version = "2.37.3" %}
+{% set version = "2.37.4" %}
+{% set deselect_tests = "" %}
+{% set deselect_tests = 'deselect_tests + " --deselect=tests/test_format.py::test_preferring_arbitrary"' %}
+{% set deselect_tests = 'deselect_tests + " --deselect=tests/test_format.py::test_missing_format"' %}
 
+# imageio-ffmpeg package is not available in channel
+# E       KeyError: 'imageio.plugins.ffmpeg'
+# E       AssertionError: assert 'NPZ' == 'FFMPEG'
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451
+  sha256: e45cbc5e83502047fb138f7f585f7f105a136a57eea5f4b3cfc6ce1b52720bd3
 
 build:
   number: 0
@@ -23,17 +29,13 @@ requirements:
     - python
     - setuptools >=61.0
     - numpy {{ numpy }}
+    - wheel
   run:
     - python
     - numpy
     - pillow >=8.3.2
-
-{% set deselect_tests = "" %}
-# imageio-ffmpeg package is not available in channel
-# E       KeyError: 'imageio.plugins.ffmpeg'
-{% set deselect_tests = deselect_tests + " --deselect=tests/test_format.py::test_preferring_arbitrary" %}
-# E       AssertionError: assert 'NPZ' == 'FFMPEG'
-{% set deselect_tests = deselect_tests + " --deselect=tests/test_format.py::test_missing_format" %}
+  run_constrained:
+    - numpy >2
 
 test:
   source_files:


### PR DESCRIPTION
imageio 2.37.4 

**Destination channel:** Defaults

### Links

- [PKG-16812]
- dev_url:        https://github.com/imageio/imageio/tree/v2.37.4
- conda_forge:    https://github.com/conda-forge/imageio-feedstock
- pypi:           https://pypi.org/project/imageio/2.37.4
- pypi inspector: https://inspector.pypi.io/project/imageio/2.37.4

### Explanation of changes:

- new version number


[PKG-16812]: https://anaconda.atlassian.net/browse/PKG-16812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ